### PR TITLE
[#2] Add support for symbolic memory addresses

### DIFF
--- a/src/recontex.hxx
+++ b/src/recontex.hxx
@@ -21,7 +21,7 @@ namespace rstc {
         std::vector<Context const *> get_contexts(Flo const &flo,
                                                   Address address) const;
 
-        static std::optional<uintptr_t>
+        static virt::Value
         get_memory_address(ZydisDecodedOperand const &op,
                            Context const &context);
 

--- a/src/restruc.cxx
+++ b/src/restruc.cxx
@@ -316,14 +316,12 @@ size_t Restruc::get_field_count(ZydisDecodedOperand const &mem_op,
                     break;
                 case ZYDIS_OPERAND_TYPE_MEMORY:
                     for (auto const &context : contexts) {
-                        if (auto address =
-                                Recontex::get_memory_address(op2, context);
-                            address) {
-                            if (virt::Value value =
-                                    context->get_memory(*address, 8);
-                                !value.is_symbolic()) {
-                                count = std::max(count, value.value());
-                            }
+                        auto address =
+                            Recontex::get_memory_address(op2, context)
+                                .raw_address_value();
+                        if (virt::Value value = context->get_memory(address, 8);
+                            !value.is_symbolic()) {
+                            count = std::max(count, value.value());
                         }
                     }
                     break;

--- a/src/virtual/memory.hxx
+++ b/src/virtual/memory.hxx
@@ -13,9 +13,10 @@ namespace rstc::virt {
     class Memory {
     public:
         struct Values {
+            uintptr_t address;
             std::vector<Value> container;
 
-            Values(size_t size, Address default_source);
+            Values(uintptr_t address, size_t size, Address default_source);
 
             operator Value() const;
         };

--- a/src/virtual/registers.cxx
+++ b/src/virtual/registers.cxx
@@ -341,6 +341,18 @@ bool Registers::is_tracked(ZydisRegister zydis_reg) const
     return register_map.contains(zydis_reg);
 }
 
+std::optional<Registers::Reg> Registers::from_zydis(ZydisRegister zydis_reg)
+{
+    if (auto it = reg_promotion_map_.find(zydis_reg);
+        it != reg_promotion_map_.end()) {
+        zydis_reg = it->second;
+    }
+    if (auto it = register_map.find(zydis_reg); it != register_map.end()) {
+        return it->second;
+    }
+    return std::nullopt;
+}
+
 void Registers::initialize_holder(Holder &holder, size_t begin, size_t end)
 {
     auto middle = begin + (end - begin) / 2;

--- a/src/virtual/registers.hxx
+++ b/src/virtual/registers.hxx
@@ -93,6 +93,8 @@ namespace rstc::virt {
 
         bool is_tracked(ZydisRegister zydis_reg) const;
 
+        static std::optional<Reg> from_zydis(ZydisRegister zydis_reg);
+
         static const std::unordered_map<ZydisRegister, Registers::Reg>
             register_map;
 

--- a/src/virtual/value.cxx
+++ b/src/virtual/value.cxx
@@ -6,7 +6,7 @@ using namespace rstc::virt;
 std::atomic<uintptr_t> Value::Symbol::next_id_ = 1;
 
 Value::Symbol::Symbol(uintptr_t id, intptr_t offset)
-    : id_(next_id_++)
+    : id_(id ? id : next_id_++)
     , offset_(offset)
 {
 }

--- a/src/virtual/value.hxx
+++ b/src/virtual/value.hxx
@@ -51,6 +51,14 @@ namespace rstc::virt {
             return value();
         }
 
+        inline uintptr_t raw_address_value() const
+        {
+            if (is_symbolic()) {
+                return symbol().id();
+            }
+            return value();
+        }
+
         inline bool operator<(Value const &rhs) const
         {
             return raw_value() < rhs.raw_value();


### PR DESCRIPTION
By adding this support it was possible to resolve original issue. This makes symbolic memory addresses the same in the same contexts, which generate the same symbolic values from those same symbolic addresses.